### PR TITLE
Derive plugin version from header to prevent perpetual update

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,12 @@ WordPress booking plugin with:
 ## Auto-updates
 Create a GitHub **Release** tag (e.g. `v1.2.1`) — WordPress will offer an update.
 
+## Release
+When preparing a new release, bump the `Version` header at the top of
+`reeserva-booking-suite.php` and create a matching Git tag. The
+`RSV_VER` constant is derived from the header automatically so the
+updater compares against the correct version.
+
 ## Stripe
 Set keys under **Reeserva → Email & Payments → Stripe**. If disabled, bookings confirm without payment.
 

--- a/reeserva-booking-suite.php
+++ b/reeserva-booking-suite.php
@@ -10,7 +10,9 @@
  */
 if ( ! defined( 'ABSPATH' ) ) exit;
 
-define('RSV_VER','1.5.0');
+// Derive plugin version from header to keep constants in sync with the release version.
+$rsv_meta = get_file_data(__FILE__, ['Version' => 'Version'], false);
+define('RSV_VER', $rsv_meta['Version']);
 define('RSV_PATH', plugin_dir_path(__FILE__));
 define('RSV_URL',  plugin_dir_url(__FILE__));
 //test


### PR DESCRIPTION
## Summary
- Derive `RSV_VER` from plugin header to keep version checks in sync
- Document release process noting header version bump and automatic constant

## Testing
- `php -l reeserva-booking-suite.php`
- `php -l includes/updater.php`
- `php -r '$remote="1.7.0"; preg_match("/Version:\\s*([0-9.]+)/", file_get_contents("reeserva-booking-suite.php"), $m); $current=$m[1]; echo "Current=$current Remote=$remote NeedsUpdate=".(version_compare($remote,$current,">")?"yes":"no")."\n";'`


------
https://chatgpt.com/codex/tasks/task_e_689f0b5a7978833288ee3999ef88cb23