### PR TITLE
Ensure updater renames GitHub source directory

### DIFF
--- a/includes/updater.php
+++ b/includes/updater.php
@@ -34,7 +34,9 @@ class Reeserva_GitHub_Updater {
     return $res;
   }
   function rename_source($source, $remote_source, $upgrader, $hook_extra){
-    if(isset($hook_extra['plugin']) && $hook_extra['plugin'] === plugin_basename($this->file)){
+    $prefix  = $this->owner.'-'.$this->repo.'-';
+    $base    = basename($source);
+    if(strpos($base, $prefix) === 0){
       $desired = trailingslashit($remote_source).$this->slug;
       if($source !== $desired && is_dir($source) && !is_dir($desired)){
         rename($source, $desired);


### PR DESCRIPTION
## Summary
- Detect GitHub zipball directories that start with `{owner}-{repo}-`
- Rename extracted directory to `reeservaplugin` before validation

## Testing
- `php -l includes/updater.php`


------
https://chatgpt.com/codex/tasks/task_e_689f1cbbc6688332a76fb0a500adfdf0