### PR TITLE
Refactor booking flow with availability search

### DIFF
--- a/assets/css/admin.css
+++ b/assets/css/admin.css
@@ -16,7 +16,7 @@
 #calendar { max-width:1000px; background:#fff; border:1px solid #eee; border-radius:12px; padding:8px; }
 
 /* subtle chips on calendar */
-.fc-event.price-event { z-index: 0 !important; position:absolute; inset:2px 4px auto 4px; border:none; background:#e6f7ed !important; color:#14532d !important; font-weight:600; border-radius:8px; padding:2px 6px; }
+.fc-event.price-event { z-index: 1 !important; position:absolute; inset:2px 4px auto 4px; border:none; background:#e6f7ed !important; color:#14532d !important; font-weight:600; border-radius:8px; padding:2px 6px; pointer-events:none; }
 .fc-event.rsv-booking { background:#fee2e2 !important; border:none; color:#7f1d1d !important; border-radius:6px; }
 .fc-daygrid-day-frame { position: relative; }
 

--- a/includes/admin-pages.php
+++ b/includes/admin-pages.php
@@ -44,7 +44,7 @@ function rsv_render_calendar(){
         </table>
       </div>
 
-      <!-- Modal -->
+      <!-- Price Modal -->
       <div id="price-modal" class="modal-overlay" aria-modal="true">
         <div class="modal-content">
           <button class="modal-close" aria-label="<?php esc_attr_e('Close','reeserva')?>">×</button>
@@ -67,6 +67,18 @@ function rsv_render_calendar(){
           <div style="display:flex;gap:8px;justify-content:flex-end;margin-top:10px">
             <button type="button" id="save-price" class="button button-primary"><?php esc_html_e('Save','reeserva');?></button>
             <button type="button" id="create-admin-booking" class="button"><?php esc_html_e('Create Reservation','reeserva')?></button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Booking Modal -->
+      <div id="booking-modal" class="modal-overlay" aria-modal="true">
+        <div class="modal-content">
+          <button class="modal-close" aria-label="<?php esc_attr_e('Close','reeserva')?>">×</button>
+          <h2><?php esc_html_e('Reservation Details','reeserva')?></h2>
+          <div id="booking-info"></div>
+          <div style="text-align:right;margin-top:10px">
+            <a id="booking-edit-link" href="#" class="button button-primary" target="_blank"><?php esc_html_e('Edit booking','reeserva')?></a>
           </div>
         </div>
       </div>

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -24,7 +24,7 @@ function rsv_get_booked(){
             'email'=> get_post_meta($post->ID,'rsv_guest_email',true),
             'phone'=> get_post_meta($post->ID,'rsv_guest_phone',true),
             'guests'=> get_post_meta($post->ID,'rsv_total_guests',true),
-            'price' => get_post_meta($post->ID,'rsv_price_paid',true),
+            'price' => get_post_meta($post->ID,'rsv_price_paid',true) ?: get_post_meta($post->ID,'rsv_booking_total',true),
             'payment_method'=> get_post_meta($post->ID,'rsv_payment_method',true),
             'stripe_session'=> get_post_meta($post->ID,'rsv_stripe_session',true),
             'stripe_payment_intent'=> get_post_meta($post->ID,'rsv_stripe_payment_intent',true),

--- a/includes/ajax.php
+++ b/includes/ajax.php
@@ -16,9 +16,19 @@ function rsv_get_booked(){
         $co = get_post_meta($post->ID,'rsv_check_out',true);
         if(!$ci || !$co) continue;
         $events[] = [
+            'id'    => $post->ID,
             'title' => get_post_meta($post->ID,'rsv_guest_name',true) ?: __('Booking','reeserva'),
             'start' => $ci,
             'end'   => $co,
+            'guest_name'=> get_post_meta($post->ID,'rsv_guest_name',true),
+            'email'=> get_post_meta($post->ID,'rsv_guest_email',true),
+            'phone'=> get_post_meta($post->ID,'rsv_guest_phone',true),
+            'guests'=> get_post_meta($post->ID,'rsv_total_guests',true),
+            'price' => get_post_meta($post->ID,'rsv_price_paid',true),
+            'payment_method'=> get_post_meta($post->ID,'rsv_payment_method',true),
+            'stripe_session'=> get_post_meta($post->ID,'rsv_stripe_session',true),
+            'stripe_payment_intent'=> get_post_meta($post->ID,'rsv_stripe_payment_intent',true),
+            'notes' => get_post_meta($post->ID,'rsv_booking_notes',true),
         ];
     }
     wp_send_json_success($events);

--- a/includes/cpt.php
+++ b/includes/cpt.php
@@ -79,3 +79,41 @@ add_action('save_post_rsv_accomm', function($post_id){
         update_post_meta($post_id,'rsv_ical_sources',$lines);
     }
 });
+
+// Booking details meta box
+add_action('add_meta_boxes', function(){
+    add_meta_box('rsv_booking_meta', __('Booking details','reeserva'),'rsv_render_booking_meta','rsv_booking','normal','high');
+});
+
+function rsv_render_booking_meta($post){
+    $name = get_post_meta($post->ID,'rsv_guest_name',true);
+    $email= get_post_meta($post->ID,'rsv_guest_email',true);
+    $phone= get_post_meta($post->ID,'rsv_guest_phone',true);
+    $ci   = get_post_meta($post->ID,'rsv_check_in',true);
+    $co   = get_post_meta($post->ID,'rsv_check_out',true);
+    $gu   = get_post_meta($post->ID,'rsv_total_guests',true);
+    $price= get_post_meta($post->ID,'rsv_price_paid',true);
+    $method = get_post_meta($post->ID,'rsv_payment_method',true);
+    $notes = get_post_meta($post->ID,'rsv_booking_notes',true);
+    $session = get_post_meta($post->ID,'rsv_stripe_session',true);
+    $intent  = get_post_meta($post->ID,'rsv_stripe_payment_intent',true);
+    ?>
+    <table class="form-table">
+      <tbody>
+        <tr><th><?php esc_html_e('Guest','reeserva');?></th><td><?php echo esc_html($name);?></td></tr>
+        <tr><th><?php esc_html_e('Email','reeserva');?></th><td><?php echo esc_html($email);?></td></tr>
+        <tr><th><?php esc_html_e('Phone','reeserva');?></th><td><?php echo esc_html($phone);?></td></tr>
+        <tr><th><?php esc_html_e('Check-in','reeserva');?></th><td><?php echo esc_html($ci);?></td></tr>
+        <tr><th><?php esc_html_e('Check-out','reeserva');?></th><td><?php echo esc_html($co);?></td></tr>
+        <tr><th><?php esc_html_e('Guests','reeserva');?></th><td><?php echo intval($gu);?></td></tr>
+        <tr><th><?php esc_html_e('Price paid','reeserva');?></th><td><?php echo esc_html($price);?></td></tr>
+        <tr><th><?php esc_html_e('Payment method','reeserva');?></th><td><?php echo esc_html($method);?></td></tr>
+        <?php if($method==='stripe'): ?>
+          <tr><th><?php esc_html_e('Stripe session','reeserva');?></th><td><?php echo esc_html($session);?></td></tr>
+          <?php if($intent): ?><tr><th><?php esc_html_e('Payment intent','reeserva');?></th><td><?php echo esc_html($intent);?></td></tr><?php endif; ?>
+        <?php endif; ?>
+        <tr><th><?php esc_html_e('Notes','reeserva');?></th><td><?php echo nl2br(esc_html($notes));?></td></tr>
+      </tbody>
+    </table>
+    <?php
+}

--- a/includes/cpt.php
+++ b/includes/cpt.php
@@ -93,6 +93,7 @@ function rsv_render_booking_meta($post){
     $co   = get_post_meta($post->ID,'rsv_check_out',true);
     $gu   = get_post_meta($post->ID,'rsv_total_guests',true);
     $price= get_post_meta($post->ID,'rsv_price_paid',true);
+    if($price==='') $price = get_post_meta($post->ID,'rsv_booking_total',true);
     $method = get_post_meta($post->ID,'rsv_payment_method',true);
     $notes = get_post_meta($post->ID,'rsv_booking_notes',true);
     $session = get_post_meta($post->ID,'rsv_stripe_session',true);

--- a/includes/payments.php
+++ b/includes/payments.php
@@ -10,16 +10,27 @@ function rsv_stripe_checkout(){
     $accomm_id = intval($_POST['accomm'] ?? 0);
     $ci = sanitize_text_field($_POST['ci'] ?? '');
     $co = sanitize_text_field($_POST['co'] ?? '');
-    $name = sanitize_text_field($_POST['name'] ?? '');
-    $email= sanitize_email($_POST['email'] ?? '');
-    if(!$accomm_id||!$ci||!$co||!$name||!$email) wp_send_json_error(['message'=>'Missing fields']);
+    $fname = sanitize_text_field($_POST['first_name'] ?? '');
+    $lname = sanitize_text_field($_POST['last_name'] ?? '');
+    $phone = sanitize_text_field($_POST['phone'] ?? '');
+    $guests = max(1, intval($_POST['guests'] ?? 1));
+    $notes  = sanitize_text_field($_POST['notes'] ?? '');
+    $name  = trim($fname.' '.$lname);
+    $email = sanitize_email($_POST['email'] ?? '');
+    if(!$accomm_id||!$ci||!$co||!$fname||!$lname||!$email||!$phone) wp_send_json_error(['message'=>'Missing fields']);
 
-    $total = rsv_quote_total($accomm_id,$ci,$co);
+    $total = rsv_quote_total($accomm_id,$ci,$co,$guests);
     $amount = max(0, round($total*100)); // cents
     if ($amount < 50) $amount = 50;
 
-    $success = add_query_arg(['rsv_stripe'=>'return','session_id'=>'{CHECKOUT_SESSION_ID}','accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co,'name'=>rawurlencode($name),'email'=>rawurlencode($email)], rsv_checkout_url());
-    $cancel  = add_query_arg(['step'=>2,'accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co], rsv_checkout_url());
+    $success = add_query_arg([
+        'rsv_stripe'=>'return','session_id'=>'{CHECKOUT_SESSION_ID}',
+        'accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co,
+        'first_name'=>rawurlencode($fname),'last_name'=>rawurlencode($lname),
+        'email'=>rawurlencode($email),'phone'=>rawurlencode($phone),'guests'=>$guests,
+        'notes'=>rawurlencode($notes)
+    ], rsv_checkout_url());
+    $cancel  = add_query_arg(['accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co,'guests'=>$guests], rsv_checkout_url());
 
     $body = [
         'mode' => 'payment',
@@ -37,7 +48,10 @@ function rsv_stripe_checkout(){
             ],
         ]],
         'metadata' => [
-            'accomm_id'=>$accomm_id,'ci'=>$ci,'co'=>$co,'guest_name'=>$name,'guest_email'=>$email,
+            'accomm_id'=>$accomm_id,'ci'=>$ci,'co'=>$co,
+            'guest_first_name'=>$fname,'guest_last_name'=>$lname,
+            'guest_phone'=>$phone,'guest_email'=>$email,'guests'=>$guests,
+            'notes'=>$notes,
         ]
     ];
     $headers = [

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -3,56 +3,88 @@
 if ( ! defined( 'ABSPATH' ) ) exit;
 
 add_shortcode('rsv_search', function(){
-    $types = get_posts(['post_type'=>'rsv_accomm','post_status'=>'publish','numberposts'=>-1]);
-    $action = esc_url( rsv_checkout_url() );
-    ob_start(); ?>
-    <form class="ehb-search-form" method="get" action="<?php echo $action; ?>" style="display:flex;gap:10px;flex-wrap:wrap;margin:12px 0">
-      <input type="hidden" name="step" value="1">
-      <label><?php esc_html_e('Accommodation','reeserva'); ?>
-        <select name="accomm" required>
-          <?php foreach($types as $t): ?><option value="<?php echo esc_attr($t->ID); ?>"><?php echo esc_html(get_the_title($t)); ?></option><?php endforeach; ?>
-        </select>
-      </label>
-      <label><?php esc_html_e('Check-in','reeserva'); ?> <input type="date" name="ci" required></label>
-      <label><?php esc_html_e('Check-out','reeserva'); ?> <input type="date" name="co" required></label>
+    $ci = sanitize_text_field($_GET['ci'] ?? '');
+    $co = sanitize_text_field($_GET['co'] ?? '');
+    $guests = max(1, intval($_GET['guests'] ?? 1));
+    ob_start();
+    ?>
+    <form class="ehb-search-form" method="get" action="" style="display:flex;gap:10px;flex-wrap:wrap;margin:12px 0">
+      <label><?php esc_html_e('Check-in','reeserva'); ?> <input type="date" name="ci" value="<?php echo esc_attr($ci); ?>" required></label>
+      <label><?php esc_html_e('Check-out','reeserva'); ?> <input type="date" name="co" value="<?php echo esc_attr($co); ?>" required></label>
+      <label><?php esc_html_e('Guests','reeserva'); ?> <input type="number" name="guests" min="1" value="<?php echo esc_attr($guests); ?>" required></label>
       <button type="submit"><?php esc_html_e('Search','reeserva'); ?></button>
     </form>
-    <?php return ob_get_clean();
+    <?php
+    if($ci && $co && $guests){
+        $types = get_posts(['post_type'=>'rsv_accomm','post_status'=>'publish','numberposts'=>-1]);
+        $is_available = function($accomm,$a,$b){
+            $bookings = get_posts(['post_type'=>'rsv_booking','numberposts'=>-1,'post_status'=>['publish','confirmed','pending'],
+                'meta_query'=>[['key'=>'rsv_booking_accomm','value'=>$accomm,'compare'=>'=']] ]);
+            foreach($bookings as $bk){
+                $bci=get_post_meta($bk->ID,'rsv_check_in',true);
+                $bco=get_post_meta($bk->ID,'rsv_check_out',true);
+                if(rsv_date_range_overlaps($a,$b,$bci,$bco)) return false;
+            }
+            return true;
+        };
+        echo '<div class="rsv-results" style="display:grid;gap:20px;margin-top:20px">';
+        $found=false;
+        foreach($types as $t){
+            $cap = (int) get_post_meta($t->ID,'rsv_max_guests',true);
+            if($cap < $guests) continue;
+            if(!$is_available($t->ID,$ci,$co)) continue;
+            $total = rsv_quote_total($t->ID,$ci,$co,$guests);
+            $url = add_query_arg(['accomm'=>$t->ID,'ci'=>$ci,'co'=>$co,'guests'=>$guests], rsv_checkout_url());
+            echo '<div class="rsv-result"><h4>'.esc_html(get_the_title($t)).'</h4><p>€'.esc_html(number_format($total,2)).'</p>';
+            echo '<a class="btn-primary" href="'.esc_url($url).'">'.esc_html__('Book','reeserva').'</a></div>';
+            $found=true;
+        }
+        if(!$found) echo '<p>'.esc_html__('No accommodations available for these dates.','reeserva').'</p>';
+        echo '</div>';
+    }
+    return ob_get_clean();
 });
 
 add_shortcode('rsv_checkout', function(){
     wp_enqueue_style('rsv-checkout', RSV_URL.'assets/css/checkout.css', [], RSV_VER);
-    $step = max(1, intval($_GET['step'] ?? ($_POST['step'] ?? 1)));
     $accomm_id = intval($_GET['accomm'] ?? ($_POST['accomm'] ?? 0));
     $ci = sanitize_text_field($_GET['ci'] ?? ($_POST['ci'] ?? ''));
     $co = sanitize_text_field($_GET['co'] ?? ($_POST['co'] ?? ''));
+    $guests = max(1, intval($_GET['guests'] ?? ($_POST['guests'] ?? 1)));
+    $total = rsv_quote_total($accomm_id,$ci,$co,$guests);
 
-    // Handle Stripe return
     if (isset($_GET['rsv_stripe']) && $_GET['rsv_stripe']==='return' && !empty($_GET['session_id'])){
         $session = rsv_stripe_retrieve_session(sanitize_text_field($_GET['session_id']));
-        echo '<div class="ehb-wizard"><div class="steps"><div class="step active">1</div><div class="line active"></div><div class="step active">2</div><div class="line active"></div><div class="step active">3</div></div>';
-        echo '<div class="card">';
+        echo '<div class="ehb-wizard"><div class="card">';
         if($session && ($session['payment_status'] ?? '') === 'paid'){
-            $accomm_id = intval($_GET['accomm'] ?? 0);
-            $ci = sanitize_text_field($_GET['ci'] ?? '');
-            $co = sanitize_text_field($_GET['co'] ?? '');
-            $name = sanitize_text_field($_GET['name'] ?? '');
+            $fname = sanitize_text_field($_GET['first_name'] ?? '');
+            $lname = sanitize_text_field($_GET['last_name'] ?? '');
             $email = sanitize_email($_GET['email'] ?? '');
-            $notes='';
-            // Create booking if not exists with same session id
+            $phone = sanitize_text_field($_GET['phone'] ?? '');
+            $notes = sanitize_textarea_field($_GET['notes'] ?? '');
+            $full = trim($fname.' '.$lname);
             $exists = get_posts(['post_type'=>'rsv_booking','post_status'=>['confirmed','publish'],'numberposts'=>1,
                 'meta_query'=>[['key'=>'rsv_stripe_session','value'=>sanitize_text_field($_GET['session_id']),'compare'=>'=']]]);
             if(!$exists){
-                $bid = wp_insert_post(['post_type'=>'rsv_booking','post_status'=>'confirmed','post_title'=>sprintf(__('Booking: %s','reeserva'), $name),'post_content'=>$notes]);
+                $bid = wp_insert_post(['post_type'=>'rsv_booking','post_status'=>'confirmed','post_title'=>sprintf(__('Booking: %s','reeserva'), $full),'post_content'=>'']);
                 if(!is_wp_error($bid) && $bid){
                     update_post_meta($bid,'rsv_booking_accomm',$accomm_id);
                     update_post_meta($bid,'rsv_check_in',$ci);
                     update_post_meta($bid,'rsv_check_out',$co);
-                    update_post_meta($bid,'rsv_guest_name',$name);
+                    update_post_meta($bid,'rsv_guest_first_name',$fname);
+                    update_post_meta($bid,'rsv_guest_last_name',$lname);
+                    update_post_meta($bid,'rsv_guest_name',$full);
                     update_post_meta($bid,'rsv_guest_email',$email);
+                    update_post_meta($bid,'rsv_guest_phone',$phone);
+                    update_post_meta($bid,'rsv_total_guests',$guests);
+                    update_post_meta($bid,'rsv_booking_notes',$notes);
+                    update_post_meta($bid,'rsv_price_paid',$total);
+                    update_post_meta($bid,'rsv_payment_method','stripe');
                     update_post_meta($bid,'rsv_payment_status','paid');
                     update_post_meta($bid,'rsv_stripe_session',sanitize_text_field($_GET['session_id']));
-                    do_action('rsv_booking_confirmed', $bid, ['accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co,'name'=>$name,'email'=>$email]);
+                    if(!empty($session['payment_intent']))
+                        update_post_meta($bid,'rsv_stripe_payment_intent',sanitize_text_field($session['payment_intent']));
+                    do_action('rsv_booking_confirmed', $bid, ['accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co,'name'=>$full,'email'=>$email]);
                     echo '<div class="confirm"><div class="badge">✔</div><h3>'.esc_html__('Booking confirmed','reeserva').'</h3>';
                     echo '<p><strong>'.esc_html__('Reference','reeserva').':</strong> '.intval($bid).'</p>';
                     echo '<a class="btn-secondary" href="'.esc_url( get_permalink($accomm_id) ).'">'.esc_html__('Back to listing','reeserva').'</a></div>';
@@ -72,6 +104,10 @@ add_shortcode('rsv_checkout', function(){
         return '';
     }
 
+    if (!$accomm_id || !$ci || !$co){
+        return '<div class="ehb-wizard"><div class="card"><p>'.esc_html__('Missing data. Please start again.','reeserva').'</p></div></div>';
+    }
+
     $is_available = function($accomm,$a,$b){
         $bookings = get_posts(['post_type'=>'rsv_booking','numberposts'=>-1,'post_status'=>['publish','confirmed','pending'],
             'meta_query'=>[['key'=>'rsv_booking_accomm','value'=>$accomm,'compare'=>'=']] ]);
@@ -83,86 +119,80 @@ add_shortcode('rsv_checkout', function(){
         return true;
     };
 
-    ob_start();
-    echo '<div class="ehb-wizard">';
-    echo '<div class="steps"><div class="step '.($step>=1?'active':'').'">1</div><div class="line '.($step>=2?'active':'').'"></div><div class="step '.($step>=2?'active':'').'">2</div><div class="line '.($step>=3?'active':'').'"></div><div class="step '.($step>=3?'active':'').'">3</div></div>';
-
-    if ($step === 1) {
-        echo '<div class="card"><h2>'.esc_html__('Your stay','reeserva').'</h2>';
-        $types = get_posts(['post_type'=>'rsv_accomm','post_status'=>'publish','numberposts'=>-1]);
-        echo '<form method="get" class="form-grid">';
-        echo '<input type="hidden" name="step" value="2">';
-        echo '<label>'.esc_html__('Accommodation','reeserva').'<select name="accomm" required>';
-        foreach($types as $t){ printf('<option value="%d" %s>%s</option>', $t->ID, selected($accomm_id,$t->ID,false), esc_html(get_the_title($t))); }
-        echo '</select></label>';
-        echo '<label>'.esc_html__('Check-in','reeserva').'<input type="date" name="ci" value="'.esc_attr($ci).'" required></label>';
-        echo '<label>'.esc_html__('Check-out','reeserva').'<input type="date" name="co" value="'.esc_attr($co).'" required></label>';
-        echo '<button class="btn-primary" type="submit">'.esc_html__('Continue','reeserva').'</button></form></div></div>';
-        return ob_get_clean();
+    if (!$is_available($accomm_id,$ci,$co)){
+        return '<div class="ehb-wizard"><div class="card"><p>'.esc_html__('Sorry, these dates are no longer available.','reeserva').'</p></div></div>';
     }
 
-    if (!$accomm_id || !$ci || !$co) { echo '<div class="card"><p>'.esc_html__('Missing data. Please start again.','reeserva').'</p></div></div>'; return ob_get_clean(); }
-
-    if ($step === 2) {
-        echo '<div class="card"><h2>'.esc_html__('Guest details','reeserva').'</h2>';
-        echo '<div class="summary">'.esc_html(get_the_title($accomm_id)).' • '.esc_html($ci).' → '.esc_html($co).'</div>';
-        if (!$is_available($accomm_id,$ci,$co)) { echo '<p class="error">'.esc_html__('Sorry, these dates are no longer available.','reeserva').'</p></div></div>'; return ob_get_clean(); }
-        echo '<form method="post" class="form-grid">';
-        echo '<input type="hidden" name="step" value="3"><input type="hidden" name="accomm" value="'.esc_attr($accomm_id).'"><input type="hidden" name="ci" value="'.esc_attr($ci).'"><input type="hidden" name="co" value="'.esc_attr($co).'">';
-        echo '<label>'.esc_html__('Full name','reeserva').'<input type="text" name="name" required></label>';
-        echo '<label>'.esc_html__('Email','reeserva').'<input type="email" name="email" required></label>';
-        echo '<label>'.esc_html__('Notes (optional)','reeserva').'<textarea name="notes" rows="3"></textarea></label>';
-        echo '<button class="btn-primary" type="submit">'.esc_html__('Review & pay','reeserva').'</button></form></div></div>';
-        return ob_get_clean();
+    $cap = (int) get_post_meta($accomm_id,'rsv_max_guests',true);
+    if($guests > $cap){
+        return '<div class="ehb-wizard"><div class="card"><p>'.esc_html__('Too many guests for this accommodation.','reeserva').'</p></div></div>';
     }
 
-    if ($step === 3) {
-        $name  = sanitize_text_field($_POST['name'] ?? '');
+    $p = rsv_get_payment_settings();
+
+    if(!$p['stripe_enabled'] && $_SERVER['REQUEST_METHOD']==='POST' && isset($_POST['first_name'])){
+        $fname = sanitize_text_field($_POST['first_name'] ?? '');
+        $lname = sanitize_text_field($_POST['last_name'] ?? '');
         $email = sanitize_email($_POST['email'] ?? '');
+        $phone = sanitize_text_field($_POST['phone'] ?? '');
         $notes = sanitize_textarea_field($_POST['notes'] ?? '');
-        echo '<div class="card"><h2>'.esc_html__('Review & payment','reeserva').'</h2>';
-        echo '<div class="summary">'.esc_html(get_the_title($accomm_id)).' • '.esc_html($ci).' → '.esc_html($co).'</div>';
-        $total = rsv_quote_total($accomm_id,$ci,$co);
-        echo '<ul class="review"><li><strong>'.esc_html__('Guest','reeserva').':</strong> '.esc_html($name).'</li><li><strong>'.esc_html__('Email','reeserva').':</strong> '.esc_html($email).'</li><li><strong>'.esc_html__('Total','reeserva').':</strong> €'.esc_html(number_format($total,2)).'</li></ul>';
-
-        $p = rsv_get_payment_settings();
-        if ($p['stripe_enabled']){
-            // Stripe flow
-            echo '<button id="rsv-pay" class="btn-primary">'.esc_html__('Pay with card','reeserva').'</button>';
-            echo '<script src="https://js.stripe.com/v3/"></script>';
-            echo '<script>
-            document.getElementById("rsv-pay").addEventListener("click", function(){
-                var fd=new FormData(); fd.append("action","rsv_stripe_checkout");
-                fd.append("accomm","'.esc_js($accomm_id).'"); fd.append("ci","'.esc_js($ci).'"); fd.append("co","'.esc_js($co).'");
-                fd.append("name","'.esc_js($name).'"); fd.append("email","'.esc_js($email).'");
-                fetch("'.esc_js(admin_url('admin-ajax.php')).'", {method:"POST", body:fd, credentials:"same-origin"})
-                .then(r=>r.json()).then(function(res){
-                    if(res && res.success && res.data && res.data.url){ window.location = res.data.url; }
-                    else{ alert("Stripe error: "+(res && (res.data && res.data.message || res.message) || "unknown")); }
-                }).catch(function(){ alert("Network error"); });
-            });
-            </script>';
-            echo '<p style="margin-top:8px"><a class="btn-secondary" href="'.esc_url( add_query_arg(['step'=>2,'accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co], rsv_checkout_url()) ).'">'.esc_html__('Back','reeserva').'</a></p>';
-        } else {
-            // No Stripe: confirm directly
-            if (!$name || !$email) { echo '<p class="error">'.esc_html__('Please go back and fill your details.','reeserva').'</p></div></div>'; return ob_get_clean(); }
-            $bid = wp_insert_post(['post_type'=>'rsv_booking','post_status'=>'confirmed','post_title'=>sprintf(__('Booking: %s','reeserva'), $name),'post_content'=>$notes]);
-            if (!is_wp_error($bid) && $bid) {
-                update_post_meta($bid,'rsv_booking_accomm', $accomm_id);
-                update_post_meta($bid,'rsv_check_in',      $ci);
-                update_post_meta($bid,'rsv_check_out',     $co);
-                update_post_meta($bid,'rsv_guest_name',    $name);
-                update_post_meta($bid,'rsv_guest_email',   $email);
-                update_post_meta($bid,'rsv_payment_status','confirmed');
-                do_action('rsv_booking_confirmed', $bid, ['accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co,'name'=>$name,'email'=>$email,'total'=>$total]);
-                echo '<div class="confirm"><div class="badge">✔</div><h3>'.esc_html__('Booking confirmed','reeserva').'</h3>';
-                echo '<p><strong>'.esc_html__('Reference','reeserva').':</strong> '.intval($bid).'</p>';
-                echo '<a class="btn-secondary" href="'.esc_url( get_permalink($accomm_id) ).'">'.esc_html__('Back to listing','reeserva').'</a></div>';
-            } else {
-                echo '<p class="error">'.esc_html__('Could not create booking. Please try again.','reeserva').'</p>';
-            }
+        if(!$fname || !$lname || !$email || !$phone){
+            echo '<div class="ehb-wizard"><div class="card"><p>'.esc_html__('Please fill all fields.','reeserva').'</p></div></div>';
+            return '';
         }
-        echo '</div></div>'; return ob_get_clean();
+        $full = trim($fname.' '.$lname);
+        $bid = wp_insert_post(['post_type'=>'rsv_booking','post_status'=>'confirmed','post_title'=>sprintf(__('Booking: %s','reeserva'), $full),'post_content'=>'']);
+        if(!is_wp_error($bid) && $bid){
+            update_post_meta($bid,'rsv_booking_accomm',$accomm_id);
+            update_post_meta($bid,'rsv_check_in',$ci);
+            update_post_meta($bid,'rsv_check_out',$co);
+            update_post_meta($bid,'rsv_guest_first_name',$fname);
+            update_post_meta($bid,'rsv_guest_last_name',$lname);
+            update_post_meta($bid,'rsv_guest_name',$full);
+            update_post_meta($bid,'rsv_guest_email',$email);
+            update_post_meta($bid,'rsv_guest_phone',$phone);
+            update_post_meta($bid,'rsv_total_guests',$guests);
+            update_post_meta($bid,'rsv_booking_notes',$notes);
+            update_post_meta($bid,'rsv_price_paid',$total);
+            update_post_meta($bid,'rsv_payment_method','manual');
+            update_post_meta($bid,'rsv_payment_status','confirmed');
+            do_action('rsv_booking_confirmed', $bid, ['accomm'=>$accomm_id,'ci'=>$ci,'co'=>$co,'name'=>$full,'email'=>$email,'total'=>$total]);
+            echo '<div class="ehb-wizard"><div class="card"><div class="confirm"><div class="badge">✔</div><h3>'.esc_html__('Booking confirmed','reeserva').'</h3>';
+            echo '<p><strong>'.esc_html__('Reference','reeserva').':</strong> '.intval($bid).'</p>';
+            echo '<a class="btn-secondary" href="'.esc_url( get_permalink($accomm_id) ).'">'.esc_html__('Back to listing','reeserva').'</a></div></div></div>';
+        } else {
+            echo '<div class="ehb-wizard"><div class="card"><p class="error">'.esc_html__('Could not create booking. Please try again.','reeserva').'</p></div></div>';
+        }
+        return '';
     }
-    echo '</div>'; return ob_get_clean();
+
+    ob_start();
+    echo '<div class="ehb-wizard"><div class="card"><h2>'.esc_html__('Your details','reeserva').'</h2>';
+    echo '<div class="summary">'.esc_html(get_the_title($accomm_id)).' • '.esc_html($ci).' → '.esc_html($co).' • '.sprintf(_n('%d guest','%d guests',$guests,'reeserva'),$guests).'</div>';
+    echo '<form method="post" class="form-grid" id="rsv-book">';
+    echo '<input type="hidden" name="accomm" value="'.esc_attr($accomm_id).'"><input type="hidden" name="ci" value="'.esc_attr($ci).'"><input type="hidden" name="co" value="'.esc_attr($co).'"><input type="hidden" name="guests" value="'.esc_attr($guests).'">';
+    echo '<label>'.esc_html__('First name','reeserva').'<input type="text" name="first_name" required></label>';
+    echo '<label>'.esc_html__('Last name','reeserva').'<input type="text" name="last_name" required></label>';
+    echo '<label>'.esc_html__('Email','reeserva').'<input type="email" name="email" required></label>';
+    echo '<label>'.esc_html__('Phone','reeserva').'<input type="tel" name="phone" required></label>';
+    echo '<label>'.esc_html__('Notes','reeserva').'<textarea name="notes"></textarea></label>';
+    if($p['stripe_enabled']){
+        echo '<button id="rsv-pay" type="button" class="btn-primary">'.esc_html__('Pay now','reeserva').'</button></form>';
+        echo '<script src="https://js.stripe.com/v3/\"></script>';
+        echo '<script>
+        document.getElementById("rsv-pay").addEventListener("click", function(){
+            var fd=new FormData(document.getElementById("rsv-book"));
+            fd.append("action","rsv_stripe_checkout");
+            fetch("'.esc_js(admin_url('admin-ajax.php')).'",{method:"POST",body:fd,credentials:"same-origin"})
+            .then(r=>r.json()).then(function(res){
+                if(res && res.success && res.data && res.data.url){ window.location=res.data.url; }
+                else{ alert("Stripe error: "+(res && (res.data && res.data.message || res.message) || "unknown")); }
+            }).catch(function(){ alert("Network error"); });
+        });
+        </script>';
+    } else {
+        echo '<button class="btn-primary" type="submit">'.esc_html__('Confirm booking','reeserva').'</button></form>';
+    }
+    echo '</div></div>';
+    return ob_get_clean();
 });

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -78,6 +78,7 @@ add_shortcode('rsv_checkout', function(){
                     update_post_meta($bid,'rsv_guest_phone',$phone);
                     update_post_meta($bid,'rsv_total_guests',$guests);
                     update_post_meta($bid,'rsv_booking_notes',$notes);
+                    update_post_meta($bid,'rsv_booking_total',$total);
                     update_post_meta($bid,'rsv_price_paid',$total);
                     update_post_meta($bid,'rsv_payment_method','stripe');
                     update_post_meta($bid,'rsv_payment_status','paid');
@@ -153,6 +154,7 @@ add_shortcode('rsv_checkout', function(){
             update_post_meta($bid,'rsv_guest_phone',$phone);
             update_post_meta($bid,'rsv_total_guests',$guests);
             update_post_meta($bid,'rsv_booking_notes',$notes);
+            update_post_meta($bid,'rsv_booking_total',$total);
             update_post_meta($bid,'rsv_price_paid',$total);
             update_post_meta($bid,'rsv_payment_method','manual');
             update_post_meta($bid,'rsv_payment_status','confirmed');


### PR DESCRIPTION
## Summary
- Record guest contact, pricing, payment method, and notes on each booking
- Add booking details modal and make calendar cells fully clickable for price edits or reservation info
- Send notes through Stripe checkout and expose booking meta in the admin booking post

## Testing
- `php -l includes/payments.php`
- `php -l includes/shortcodes.php`
- `php -l includes/cpt.php`
- `php -l includes/ajax.php`
- `php -l includes/admin-pages.php`


------
https://chatgpt.com/codex/tasks/task_e_689f1e4faefc833294282168c1f53ee7